### PR TITLE
remove engine checks for spawner/yarn

### DIFF
--- a/src/spawner/index.js
+++ b/src/spawner/index.js
@@ -1,17 +1,13 @@
 
 const { spawn } = require('child_process');
-const { engines } = require('../../package.json');
 const { fileExists } = require('../common/files');
 const { join } = require('path');
-const { node } = engines;
 require('../common/engine').properNodeVersions();
 const {
-    engineCheck
-    , versionStringToObject
+    versionStringToObject
     , versionToUseValidator
     , versions
 } = require('../common/engine');
-engineCheck(node);
 const yargs = require('yargs');
 
 /**
@@ -79,10 +75,8 @@ yargs
                     , alias: 'l'
                 })
                 .check(({ name, command }) => {
-                    if(name.toLowerCase() === 'node') {
-                        if(command) {
-                            throw new Error('node cli does not support commands');
-                        }
+                    if(name.toLowerCase() === 'node' && command) {
+                        throw new Error('node cli does not support commands');
                     }
                     return true;
                 })

--- a/src/yarn/index.js
+++ b/src/yarn/index.js
@@ -1,15 +1,11 @@
 
-const { spawn } = require('child_process');
-const { engines } = require('../../package.json');
-const { node } = engines;
+const { spawn } = require('node:child_process');
 require('../common/engine').properNodeVersions();
 const {
-    engineCheck
-    , versionStringToObject
+    versionStringToObject
     , versionToUseValidator
     , versions
 } = require('../common/engine');
-engineCheck(node);
 const yargs = require('yargs');
 
 /**


### PR DESCRIPTION
## Problem

While the tools are written to run with v20 my development environment is mainly stuck on v16.  the engineCheck was preventing the code from running on <20.11

## proposed changes 

remove the engineCheck for spawner and yarn tools 