### PR TITLE
grefplus: allow multiple roots

### DIFF
--- a/src/grefplus/cmdline.js
+++ b/src/grefplus/cmdline.js
@@ -31,7 +31,7 @@ const cmdKeys = {
     , 'dev-root': {
         alias: 'r'
         , describe: 'root folder of development environment (/c/blah/blah). Default is DEVROOT'
-        , type: 'string'
+        , type: 'array'
         // eslint-disable-next-line no-process-env
         , default: process.env.DEVROOT
     }
@@ -74,14 +74,25 @@ const validateDate = (checkDate, msg) => {
  * @private
  */
 const validatePath = ({ devRoot }) => {
-    try {
-        accessSync(devRoot, constants.R_OK);
-        return lstatSync(devRoot).isDirectory();
+    let problematicRoot = null;
+
+    devRoot.forEach(root => {
+        try {
+            accessSync(root, constants.R_OK);
+            if(!lstatSync(root).isDirectory()) {
+                problematicRoot = root;
+            }
+        }
+        catch (error) {
+            problematicRoot = { root, error };
+        }
+    });
+
+    if(problematicRoot) {
+        throw new Error(`Unable to access specified dev root folder of '${problematicRoot.root}'. Due to ${problematicRoot.error.message}`);
     }
-    // eslint-disable-next-line no-unused-vars
-    catch (e) {
-        throw new Error(`Unable to access specified dev root folder of '${devRoot}'. Due to ${e.message}`);
-    }
+    return true;
+
 };
 
 /**

--- a/src/grefplus/index.js
+++ b/src/grefplus/index.js
@@ -103,11 +103,16 @@ const logErrors = (errors, isDebug, err) => {
  * Entry point
  */
 const main = () => {
-    if(options.devRoot) {
+    if(options.devRoot.length) {
         const errors = [];
         let maxRepoLength = 0;
-        const promises = allRepoPaths(options.devRoot, options.folderNames)
-            .map(repo => processRepo(repo, errors));
+        const repos = [];
+        options.devRoot.forEach(root => {
+            allRepoPaths(root, options.folderNames).forEach(repo => {
+                repos.push(repo);
+            });
+        });
+        const promises = repos.map(repo => processRepo(repo, errors));
 
         return Promise
             .all(promises)


### PR DESCRIPTION
## Problem

see #120 

## Changes 

- the root option is now an array but retains the default root
   - if `--root (-r)` is specified, then one must include the all roots, `grefp -f 04/20/24 -r $DEVROOT /f/foo`