### PR TITLE
Clean: bug fixes

### DIFF
--- a/src/clean/index.js
+++ b/src/clean/index.js
@@ -18,6 +18,12 @@ const sonar = {
             , type: 'string'
             , default: join(process.env.HOME, '.sonarlint')
         })
+        .option('age', {
+            alias: 'a'
+            , describe: 'how many days to keep. Must be an integer > 1'
+            , type: 'number'
+            , default: 2
+        })
         .option('logger', {
             type: 'object'
             , default: console
@@ -28,6 +34,13 @@ const sonar = {
                 return true;
             }
             throw new Error('root path not found');
+        })
+        .check(argv => {
+            // eslint-disable-next-line no-magic-numbers
+            if(argv.age > 1 && argv.age <= 100 && Number.isInteger(argv.age)) {
+                return true;
+            }
+            throw new Error('age must be > 1');
         })
     , handler: async (args) => {
         const { root, age, logger } = args;
@@ -61,5 +74,3 @@ yargs(hideBin(process.argv))
     .version(false)
     .strict(true)
     .parse();
-
-

--- a/test/clean.spec.js
+++ b/test/clean.spec.js
@@ -80,7 +80,7 @@ describe('Cleaner Module', () => {
     });
     describe('removeSonarTemp', function() {
         afterEach(mockFS.restore);
-        const logStub = { debug: sinon.stub() };
+        const logStub = { debug: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
         const rootPath = '.';
         const now = DateTime.now();
 


### PR DESCRIPTION
## Problem

The clean sonar was not actually removing folders because a runtime exception was triggered from there not being constants property on the `fsPromises` object.

Even when that was fixed, it still would not work because the age was undefined and a user could not alter it.

## Changes

- changed the require statement for node:fs
- Added a new option for age (-a) which allows integer values > 1 and < 100
- Added a logger message to report exceptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line option for specifying the retention period of files, enhancing user control.
	
- **Improvements**
	- Updated the `removeSonarTemp` function to allow optional `age` parameter and improved error handling for better debugging.
	- Added logging to indicate the number of folders being removed, increasing visibility of operations.

- **Tests**
	- Enhanced logging capabilities in tests for the `removeSonarTemp` function to capture additional log levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->