### PR TITLE
clean: Clean up messages to user

### DIFF
--- a/src/clean/clean.js
+++ b/src/clean/clean.js
@@ -101,8 +101,6 @@ const removeSonarTemp = async ({ root, age = 2 }, logger = console) => {
             const daysOld = Math.floor((now - ctimeMs) / DAY_MS);
             return daysOld >= age ? d : null;
         })).then(results => results.filter(Boolean));
-            return daysOld >= age;
-        });
 
         logger.info(`Removing ${foldersToDelete.length} folders which are at least ${age} days ...`);
         const deleteFolders = await Promise.allSettled(

--- a/src/clean/clean.js
+++ b/src/clean/clean.js
@@ -96,9 +96,11 @@ const removeSonarTemp = async ({ root, age = 2 }, logger = console) => {
         folders = await fsPromises.readdir(_root, { withFileTypes: true });
         const targetFolders = folders.filter(d => d.isDirectory() && (d.name.startsWith('.sonarlinttmp_') || d.name.startsWith('xodus-local-only')));
 
-        const foldersToDelete = targetFolders.filter(async d => {
+        const foldersToDelete = await Promise.all(targetFolders.map(async d => {
             const { ctimeMs } = await fsPromises.stat(join(_root, d.name)).catch(() => ({ ctimeMs: 0 }));
             const daysOld = Math.floor((now - ctimeMs) / DAY_MS);
+            return daysOld >= age ? d : null;
+        })).then(results => results.filter(Boolean));
             return daysOld >= age;
         });
 

--- a/src/clean/index.js
+++ b/src/clean/index.js
@@ -45,8 +45,7 @@ const sonar = {
     , handler: async (args) => {
         const { root, age, logger } = args;
         try {
-            const result = await removeSonarTemp({ root, age }, logger);
-            logger.info(`sonar cleanup completed, ${result} folders removed`);
+            await removeSonarTemp({ root, age }, logger);
         }
         catch (err) {
             logger.error(err.message);

--- a/src/clean/index.js
+++ b/src/clean/index.js
@@ -18,12 +18,6 @@ const sonar = {
             , type: 'string'
             , default: join(process.env.HOME, '.sonarlint')
         })
-        .option('age', {
-            alias: 'a'
-            , describe: 'how many days to keep. Must be an integer > 1'
-            , type: 'number'
-            , default: 2
-        })
         .option('logger', {
             type: 'object'
             , default: console
@@ -35,17 +29,10 @@ const sonar = {
             }
             throw new Error('root path not found');
         })
-        .check(argv => {
-            // eslint-disable-next-line no-magic-numbers
-            if(argv.age > 1 && argv.age <= 100 && Number.isInteger(argv.age)) {
-                return true;
-            }
-            throw new Error('age must be > 1');
-        })
     , handler: async (args) => {
-        const { root, age, logger } = args;
+        const { root, logger } = args;
         try {
-            await removeSonarTemp({ root, age }, logger);
+            await removeSonarTemp({ root }, logger);
         }
         catch (err) {
             logger.error(err.message);


### PR DESCRIPTION
## Problem

The logging of the removed folders did not account for folders that fell within the desired aged to delete but could not be removed because they are still in use. Thus they initial message about the number of folders found did not agree with the number actually deleted.

## Changes

- Added a count of rejected deletions on the assumption it was because they are in use still.
- modified the messaging to account for the rejected deletions
- removed the number deleted logging from the index as no longer being informative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging for folder deletion outcomes in the Sonar temporary folder removal process, providing clearer feedback on operation success.

- **Bug Fixes**
  - Improved feedback mechanism for folder deletion, addressing visibility of successful and failed deletions.

- **Documentation**
  - Added comments to clarify the purpose of functions related to temporary folders created by SonarLint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->