### PR TITLE
Updates Windows build to the latest version

### DIFF
--- a/.github/workflows/node.win.js.yml
+++ b/.github/workflows/node.win.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build and Test Windows
-    runs-on:  windows-2019
+    runs-on:  windows-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Changes the Windows build environment to 'windows-latest'. This ensures the build process uses the most recent Windows version available on GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build and test workflow to use the latest available Windows runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->