### PR TITLE
Updates gtemp alias to use git commit directly

### DIFF
--- a/src/alias.sh
+++ b/src/alias.sh
@@ -31,6 +31,6 @@ alias gl='gitlog'
 
 alias gsl='git stash list --date=local'
 alias gst='git status'
-alias gtemp='gcm --no-verify -am "temp"'
+alias gtemp='git commit --no-gpg-sign --no-verify -am "temp"'
 alias pull='git pull'
 alias stash-all='git stash save --include-untracked'


### PR DESCRIPTION
Updates the `gtemp` alias to directly use `git commit` instead of `gcm`. This ensures consistent behavior with other git commands and avoids potential dependency issues with `gcm`.